### PR TITLE
Routing organization

### DIFF
--- a/src/Context.jsx
+++ b/src/Context.jsx
@@ -1,0 +1,41 @@
+import { createContext, useState } from "react";
+import { getCurrentUser } from "./managers/AuthManager";
+
+export const AuthContext = createContext();
+
+export const AuthProvider = ({ children }) => {
+    // All your data goes here
+    const [token, setTokenState] = useState(localStorage.getItem('auth_token'))
+    const [isAdmin, setIsAdminState] = useState(localStorage.getItem('wilder_admin'))
+    const [currentUserId, setCurrentUserId] = useState(0)
+
+    const setToken = (newToken) => {
+        localStorage.setItem('auth_token', newToken)
+        setTokenState(newToken)
+    }
+
+    const setAdmin = (isStaff) => {
+        localStorage.setItem('wilder_admin', isStaff)
+        setIsAdminState(isStaff)
+    }
+
+    const fetchCurrentUserId = () => {
+        if (localStorage.getItem("auth_token")) {
+            getCurrentUser().then(data => setCurrentUserId(data.id))
+        } else {
+            setCurrentUserId(0)
+        }
+        
+    }
+
+    
+
+    // Return this context provider wrapping, it passes down the value prop to its children
+    return (
+        <AuthContext.Provider
+            value={{ token, setToken, isAdmin, setAdmin, currentUserId, fetchCurrentUserId }}
+        >
+            {children}
+        </AuthContext.Provider>
+    )
+}

--- a/src/WilderWatch.jsx
+++ b/src/WilderWatch.jsx
@@ -1,36 +1,10 @@
 import { useState } from "react";
 import ApplicationRoutes from "./routes/ApplicationRoutes.jsx";
 
-//   const router = createBrowserRouter(
-//     createRoutesFromElements(
-//     <Route
-//       element={<App />}
-//       path="/"
-//     />
-//   ));
-
-
 
 const WilderWatch = () => {
-    const [token, setTokenState] = useState(localStorage.getItem('auth_token'))
-    const [isWilderAdmin, setIsAdminState] = useState(localStorage.getItem('wilder_admin'))
-
-    const setToken = (newToken) => {
-        localStorage.setItem('auth_token', newToken)
-        setTokenState(newToken)
-    }
-
-    const setIsWilderAdmin = (isStaff) => {
-        localStorage.setItem('wilder_admin', isStaff)
-        setIsAdminState(isStaff)
-    }
     return <>
-        <ApplicationRoutes 
-        setToken={setToken} 
-        setAdmin={setIsWilderAdmin}
-        token={token}
-        isAdmin={isWilderAdmin} />
+        <ApplicationRoutes  />
     </>
 }
-
 export default WilderWatch

--- a/src/WilderWatch.jsx
+++ b/src/WilderWatch.jsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import ApplicationRoutes from "./routes/ApplicationRoutes.jsx";
 
 

--- a/src/components/auth/Authorized.jsx
+++ b/src/components/auth/Authorized.jsx
@@ -1,6 +1,9 @@
 import { Navigate, Outlet } from "react-router-dom"
+import { AuthContext } from "../../Context"
+import { useContext } from "react"
 
-export const Authorized = ({ token }) => {
+export const Authorized = () => {
+  const { token } = useContext(AuthContext)
   if (token) {
     return <Outlet />
   }

--- a/src/components/auth/Login.jsx
+++ b/src/components/auth/Login.jsx
@@ -1,8 +1,10 @@
-import { useEffect, useRef, useState } from "react"
+import { useContext, useEffect, useRef, useState } from "react"
 import { Link, useNavigate } from "react-router-dom"
 import { loginUser } from "../../managers/AuthManager"
+import { AuthContext } from "../../Context"
 
-export const Login = ({ setToken, setAdmin }) => {
+export const Login = () => {
+  const {setToken, setAdmin} = useContext(AuthContext)
   const username = useRef()
   const password = useRef()
   const navigate = useNavigate()

--- a/src/components/auth/Register.jsx
+++ b/src/components/auth/Register.jsx
@@ -1,9 +1,12 @@
-import { useRef, useState } from "react"
+import { useContext, useRef, useState } from "react"
 import { Link } from "react-router-dom"
 import { useNavigate } from "react-router-dom"
 import { registerUser } from "../../managers/AuthManager"
+import { AuthContext } from "../../Context"
 
-export const Register = ({ setToken, setAdmin }) => {
+export const Register = () => {
+  const {setToken, setAdmin} = useContext(AuthContext)
+
   const firstName = useRef()
   const lastName = useRef()
   const email = useRef()

--- a/src/components/home/Home.jsx
+++ b/src/components/home/Home.jsx
@@ -1,12 +1,18 @@
-import { useEffect, useState } from "react"
+import { useContext, useEffect, useState } from "react"
 import { deleteStudy, getAllStudies } from "../../managers/StudyManager"
 import { Link, useNavigate } from "react-router-dom"
-import { getCurrentUser } from "../../managers/AuthManager"
+import { AuthContext } from "../../Context"
 
-export const Home = ({ fetchCurrentUserId, fetchStudies, studies, currentUserId}) => {
+export const Home = () => {
+    const { currentUserId, fetchCurrentUserId } = useContext(AuthContext)
 
     const [confirmation, showConfirmation] = useState(0)
+    const [studies, setStudies] = useState([])
     const navigate = useNavigate()
+
+    const fetchStudies = () => {
+        getAllStudies().then(data => setStudies(data))
+    }
 
     useEffect(
         () => {

--- a/src/components/layouts/ApplicationLayout.jsx
+++ b/src/components/layouts/ApplicationLayout.jsx
@@ -1,0 +1,11 @@
+import { Outlet } from "react-router-dom"
+import { AuthProvider } from "../../Context"
+
+const ApplicationLayout = () => {
+    return <>
+        <AuthProvider>
+            <Outlet />
+        </AuthProvider>
+    </>
+}
+export default ApplicationLayout

--- a/src/components/nav/DropdownMenu.jsx
+++ b/src/components/nav/DropdownMenu.jsx
@@ -3,7 +3,7 @@ import './DropdownMenu.css' // Import CSS styles for the dropdown menu
 import { Link, useNavigate } from 'react-router-dom';
 import burgerIcon from "../../assets/burgericon.svg"
 
-export const DropdownMenu = ({ refreshUser, refreshStudies }) => {
+export const DropdownMenu = ({ refreshUser }) => {
     const [isOpen, setIsOpen] = useState(false) // State to track if the dropdown is open or closed
   
     const toggleDropdown = () => {
@@ -58,7 +58,6 @@ export const DropdownMenu = ({ refreshUser, refreshStudies }) => {
                       localStorage.removeItem("auth_token")
                       localStorage.removeItem("wilder_admin")
                       refreshUser()
-                      refreshStudies()
                       navigate("/", { replace: true })
                     }}>Logout</Link>
                   </div>

--- a/src/components/nav/NavBar.jsx
+++ b/src/components/nav/NavBar.jsx
@@ -2,8 +2,11 @@ import { Outlet, useNavigate } from "react-router-dom"
 import "./NavBar.css"
 import { DropdownMenu } from "./DropdownMenu"
 import wilderLogo from "../../assets/mountains.png"
+import { useContext } from "react"
+import { AuthContext } from "../../Context"
 
-export const NavBar = ({ fetchCurrentUserId, fetchStudies }) => {
+export const NavBar = () => {
+    const { fetchCurrentUserId } = useContext(AuthContext)
     const navigate = useNavigate()
 
     return (
@@ -17,7 +20,7 @@ export const NavBar = ({ fetchCurrentUserId, fetchStudies }) => {
                 
             </li>
             <li className="navbar__item navbar__menu">
-                <DropdownMenu refreshUser={fetchCurrentUserId} refreshStudies={fetchStudies} />
+                <DropdownMenu refreshUser={fetchCurrentUserId} />
             </li>
         </ul>
         <div id="main-content">

--- a/src/routes/ApplicationRoutes.jsx
+++ b/src/routes/ApplicationRoutes.jsx
@@ -17,51 +17,33 @@ import { getAllStudies } from "../managers/StudyManager";
 import { useState } from "react";
 import EditStudyForm from "../components/studies/EditStudyForm";
 import AddObservation from "../components/studies/AddObservation";
+import ApplicationLayout from "../components/layouts/ApplicationLayout";
 
-
-
-const ApplicationRoutes = ({token, setToken, isAdmin, setAdmin}) => {
-    const [studies, setStudies] = useState([])
-    const [currentUserId, setCurrentUserId] = useState(0)
-
-    const fetchStudies = () => {
-        getAllStudies().then(data => setStudies(data))
-    }
-
-    const fetchCurrentUserId = () => {
-        if (localStorage.getItem("auth_token")) {
-            getCurrentUser().then(data => setCurrentUserId(data.id))
-        } else {
-            setCurrentUserId(0)
-        }
-        
-    }
-
-    const router = createBrowserRouter(
-        createRoutesFromElements(
-            <>
-                <Route element={<Login setToken={setToken} setAdmin={setAdmin} />} path="/login" />
-                <Route element={<Register setToken={setToken} setAdmin={setAdmin} />} path="/register" />
-                <Route element={<NavBar fetchCurrentUserId={fetchCurrentUserId} fetchStudies={fetchStudies} />} path="/">
+const router = createBrowserRouter(
+    createRoutesFromElements(
+        <>
+            <Route element={<ApplicationLayout />} path="/">
+                <Route element={<Login />} path="/login" />
+                <Route element={<Register />} path="/register" />
+                <Route element={<NavBar />} path="/">
                     <Route
-                        index element={<Home 
-                            fetchCurrentUserId={fetchCurrentUserId}
-                            fetchStudies={fetchStudies}
-                            studies={studies}
-                            currentUserId={currentUserId} />}
+                        index element={<Home />}
                     />
                     <Route
                         element={<StudyDetails />}
                         path="/study/:studyId"
                     />
-                    <Route element={<Authorized token={token}/>}>
+                    <Route element={<Authorized />}>
                         <Route element={<CreateStudyForm />} path="/study/new" />
                         <Route element={<EditStudyForm />} path="/study/edit/:studyId" />
                         <Route element={<AddObservation />} path="/study/:studyId/add_observation" />
                     </Route>
                 </Route>
-            </>
-        ));
+            </Route>
+        </>
+    ));
+
+const ApplicationRoutes = () => {
 
     return <>
         <RouterProvider router={router} />

--- a/src/routes/ApplicationRoutes.jsx
+++ b/src/routes/ApplicationRoutes.jsx
@@ -4,7 +4,6 @@ import {
     Route,
     RouterProvider,
   } from "react-router-dom";
-import App from "../App";
 import { NavBar } from "../components/nav/NavBar";
 import { Home } from "../components/home/Home";
 import { Login } from "../components/auth/Login";
@@ -12,9 +11,6 @@ import { Register } from "../components/auth/Register";
 import CreateStudyForm from "../components/studies/CreateStudyForm";
 import { Authorized } from "../components/auth/Authorized";
 import StudyDetails from "../components/studies/StudyDetails";
-import { getCurrentUser } from "../managers/AuthManager";
-import { getAllStudies } from "../managers/StudyManager";
-import { useState } from "react";
 import EditStudyForm from "../components/studies/EditStudyForm";
 import AddObservation from "../components/studies/AddObservation";
 import ApplicationLayout from "../components/layouts/ApplicationLayout";


### PR DESCRIPTION
## Changes Made

- Moved `createBrowserRouter` outside of the react tree so it statically defines the set of routes, as recommended in the [docs for react-router-dom v6.4](https://reactrouter.com/en/main/routers/create-browser-router)
- Added `useContext()` to manage state needed at the highest component level.
- Created new ApplicationLayout component to pass state from ContextProvider to children since routes are no longer able to pass around state as part of the react tree.
- Removed unused imports